### PR TITLE
Fix Smooch initialization in webview form

### DIFF
--- a/Questionnaire_lastest_build_V3.html
+++ b/Questionnaire_lastest_build_V3.html
@@ -198,7 +198,7 @@
     window.addEventListener('load', () => {
       Smooch.init({
         integrationId: INTEGRATION_ID,
-        region: 'eu-1',
+        configBaseUrl: 'https://motorway-dev.zendesk.com/sc/',
         embedded: true
       })
       .then(() => Smooch.loadConversation(CONVERSATION_ID))


### PR DESCRIPTION
## Summary
- use Zendesk configBaseUrl for Smooch.init

## Testing
- `node testV3.js` *(failed: net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_e_684191a72de0832681ad4ccb91842504