### PR TITLE
Add cancellation form webview

### DIFF
--- a/Cancellation_form.html
+++ b/Cancellation_form.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Cancellation Form</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+      background-color: #f2f4f7;
+      color: #333;
+    }
+    form {
+      background: #ffeb7c;
+      padding: 24px;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      max-width: 600px;
+      margin: auto;
+    }
+    h2 {
+      margin-bottom: 24px;
+      color: #0053a0;
+      font-size: 1.5rem;
+      text-align: center;
+    }
+    .form-group { margin-bottom: 20px; }
+    label { display: block; font-weight: bold; margin-bottom: 6px; }
+    input, select, textarea {
+      width: 100%; padding: 8px 10px; border: 1px solid #ccc;
+      border-radius: 4px; font-size: 1rem; transition: border-color .2s;
+    }
+    input:focus, select:focus, textarea:focus { outline: none; border-color: #007bff; }
+    button {
+      display: block; width: 100%; padding: 12px;
+      background-color: #fafafa; color: #000;
+      border: none; border-radius: 4px; font-size: 1.1rem;
+      cursor: pointer; transition: background-color .2s;
+    }
+    button:hover { background-color: #ffffff; }
+    .sc-launcher, .sc-widget, .sk-launcher, #sk-holder iframe { display: none !important; }
+  </style>
+
+  <!-- Sunshine Conversations / Zendesk Webview SDK -->
+  <script>
+    ;(function(d,s,id){
+      var js,fjs=d.getElementsByTagName(s)[0];
+      if(d.getElementById(id)) return;
+      js=d.createElement(s); js.id=id;
+      js.src="https://static.zdassets.com/conversation-extensions/latest/sdk.js";
+      fjs.parentNode.insertBefore(js,fjs);
+    })(document,"script","WebviewSdkScript");
+
+    window.webviewSdkInit = function(WebviewSdk) {
+      if (WebviewSdk.hasFeature("close")) {
+        window.closeExtension = WebviewSdk.close.bind(WebviewSdk);
+      } else {
+        console.warn("Close not supported on this channel");
+      }
+    };
+  </script>
+</head>
+<body>
+
+  <form id="cancelForm">
+    <h2>Cancellation Request</h2>
+
+    <div class="form-group">
+      <label>Order ID</label>
+      <input type="text" name="order_id" placeholder="12345">
+    </div>
+
+    <div class="form-group">
+      <label>Reason for Cancellation</label>
+      <select name="reason" onchange="toggleDetails(this)">
+        <option value="">Select a reason</option>
+        <option value="change_of_mind">Change of mind</option>
+        <option value="better_price">Found a better price</option>
+        <option value="product_issue">Issue with product</option>
+        <option value="other">Other</option>
+      </select>
+      <div id="reasonDetails" style="display:none; margin-top:8px;">
+        <label>Please provide details</label>
+        <textarea name="reason_details" rows="3"></textarea>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>Additional Comments</label>
+      <textarea name="comments" rows="3"></textarea>
+    </div>
+
+    <button id="submitBtn" type="submit" disabled>Submit</button>
+  </form>
+
+  <script src="https://adam-s-cxt.github.io/sunshine-conversations-web/smooch.5.7.4.min.js"></script>
+
+  <script>
+    // 1) Monkey-patch fetch to log Smooch API calls
+    (function(){
+      const origFetch = window.fetch;
+      window.fetch = function(resource, options) {
+        if (typeof resource === 'string' && resource.includes('/conversations/')) {
+          console.group('[fetch]');
+          console.log('→ URL:', resource);
+          console.log('→ options:', options);
+        }
+        return origFetch(resource, options).then(response => {
+          if (response.url && response.url.includes('/conversations/')) {
+            console.log('← status:', response.status, response.statusText);
+            response.clone().text().then(text => console.log('← body:', text));
+            console.groupEnd();
+          }
+          return response;
+        });
+      };
+    })();
+
+    // 2) Wrap key Smooch methods to log arguments and results
+    (function(){
+      if (!window.Smooch) return;
+      function wrap(fnName) {
+        const original = Smooch[fnName];
+        if (!original) return;
+        Smooch[fnName] = function(...args) {
+          console.group(`[Smooch] ${fnName}`);
+          console.log('→ arguments:', args);
+          const result = original.apply(this, args);
+          if (result && typeof result.then === 'function') {
+            result.then(res => { console.log('✓ resolved:', res); console.groupEnd(); return res; })
+                  .catch(err => { console.error('✗ rejected:', err); console.groupEnd(); throw err; });
+          } else {
+            console.log('✓ returned sync value:', result);
+            console.groupEnd();
+          }
+          return result;
+        };
+      }
+      ['init','loadConversation','sendMessage','getConversationById'].forEach(wrap);
+      if (Smooch.on) {
+        Smooch.on('*', (event, payload) => console.log(`[event:${event}]`, payload));
+      }
+    })();
+
+    // 3) Initialize the SDK without rendering the widget, then load the conversation
+    (function(){
+      const INTEGRATION_ID  = "64f5a35e7e9cf2bd7bc34a37";
+      const CONVERSATION_ID = "681ca86ef34de2d9eacfd30c";
+      window.smoochReady = false;
+
+      window.addEventListener('load', () => {
+        if (typeof Smooch === 'undefined') {
+          console.error('Smooch SDK not loaded');
+          return;
+        }
+        Smooch.init({
+          integrationId: INTEGRATION_ID,
+          configBaseUrl: 'https://motorway-dev.zendesk.com/sc/',
+          embedded: true
+        })
+        .then(cfg => {
+          console.log('✅ init resolved, config:', cfg);
+          return Smooch.loadConversation(CONVERSATION_ID);
+        })
+        .then(conv => {
+          console.log('✅ loadConversation resolved, conversation:', conv);
+          window.smoochReady = true;
+          document.getElementById('submitBtn').disabled = false;
+        })
+        .catch(err => {
+          console.error('❌ init or loadConversation failed:', err);
+        });
+      });
+    })();
+
+    // Toggle extra details when reason is "other"
+    function toggleDetails(selectElem) {
+      const el = document.getElementById('reasonDetails');
+      if (selectElem.value === 'other') {
+        el.style.display = 'block';
+      } else {
+        el.style.display = 'none';
+      }
+    }
+
+    // Handle form submission
+    document.getElementById('cancelForm').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const formData = new FormData(this);
+      const data = {};
+      formData.forEach((v, k) => { data[k] = v; });
+
+      const lines = [];
+      lines.push('📋 Cancellation Request:');
+      if (data.order_id) lines.push(`– Order ID: ${data.order_id}`);
+      if (data.reason) lines.push(`– Reason: ${data.reason}`);
+      if (data.reason_details) lines.push(`– Details: ${data.reason_details}`);
+      if (data.comments) lines.push(`– Comments: ${data.comments}`);
+      const summary = lines.join('\n');
+      console.log('[Form] summary to send:', summary);
+
+      if (window.smoochReady) {
+        try {
+          const sendRes = await Smooch.sendMessage(
+            { type: 'text', text: summary },
+            CONVERSATION_ID
+          );
+          console.log('[Form] sendMessage result:', sendRes);
+
+          const conv = await Smooch.getConversationById(CONVERSATION_ID);
+          console.log('[Form] current conversation.messages:', conv.messages);
+        } catch(err) {
+          console.error('Failed to send message via Smooch:', err);
+        }
+      } else {
+        console.warn('Smooch SDK not ready, cannot send message');
+      }
+
+      if (window.closeExtension) {
+        window.closeExtension();
+      } else {
+        window.parent.postMessage({ type: 'form:submitted', data, close: true }, '*');
+      }
+
+      this.innerHTML = `
+        <h2>Thank you!</h2>
+        <p>Your cancellation request has been submitted.</p>
+        <button onclick="window.closeExtension ? window.closeExtension() : window.parent.postMessage({ type:'form:submitted', close:true }, '*')">Close</button>
+      `;
+    });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a new webview html page for demo cancellation requests

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848095475e8832685b794ea041a44e3